### PR TITLE
修复本地读取gif的bug（切换一下branch）

### DIFF
--- a/BMHandler/WXImgLoaderDefaultImpl.m
+++ b/BMHandler/WXImgLoaderDefaultImpl.m
@@ -67,16 +67,14 @@
         if (BM_InterceptorOn()) {
             // 从jsbundle读取图片
             UIImage *img = nil;
-            // 从jsbundle读取图片
             NSString *imgPath = [NSString stringWithFormat:@"%@/%@%@",K_JS_PAGES_PATH,imgUrl.host,imgUrl.path];
-            
-            if([NSData sd_contentTypeForImageData:[NSData dataWithContentsOfFile:imgPath]] == @"image/gif"){
-                
-                NSData *gifData = [NSData dataWithContentsOfFile: imgPath];
-                img = [UIImage sd_animatedGIFWithData:gifData];
-            }else {
-                img = [UIImage imageWithContentsOfFile:imgPath];
+            NSData *imgData = [NSData dataWithContentsOfFile:imgPath];
+            if ([[NSData sd_contentTypeForImageData:imgData] isEqualToString:@"image/gif"]) {
+                img = [UIImage sd_animatedGIFWithData:imgData];
+            } else {
+                img = [UIImage imageWithData:imgData];
             }
+            
             NSError *error = nil;
             
             if (!img) {

--- a/BMHandler/WXImgLoaderDefaultImpl.m
+++ b/BMHandler/WXImgLoaderDefaultImpl.m
@@ -8,6 +8,8 @@
 
 #import "WXImgLoaderDefaultImpl.h"
 #import <SDWebImage/UIImageView+WebCache.h>
+#import <SDWebImage/UIImage+GIF.h>
+#import <SDWebImage/NSData+ImageContentType.h>
 
 #define MIN_IMAGE_WIDTH 36
 #define MIN_IMAGE_HEIGHT 36
@@ -64,9 +66,17 @@
         // 拦截器
         if (BM_InterceptorOn()) {
             // 从jsbundle读取图片
+            UIImage *img = nil;
+            // 从jsbundle读取图片
             NSString *imgPath = [NSString stringWithFormat:@"%@/%@%@",K_JS_PAGES_PATH,imgUrl.host,imgUrl.path];
             
-            UIImage *img = [UIImage imageWithContentsOfFile:imgPath];
+            if([NSData sd_contentTypeForImageData:[NSData dataWithContentsOfFile:imgPath]] == @"image/gif"){
+                
+                NSData *gifData = [NSData dataWithContentsOfFile: imgPath];
+                img = [UIImage sd_animatedGIFWithData:gifData];
+            }else {
+                img = [UIImage imageWithContentsOfFile:imgPath];
+            }
             NSError *error = nil;
             
             if (!img) {


### PR DESCRIPTION
ios读取本地放在assets目录中的gif图时，无法出现动效。