### PR TITLE
新增ios读取本地html功能

### DIFF
--- a/BMWeexExtension/BMMethods.m
+++ b/BMWeexExtension/BMMethods.m
@@ -279,7 +279,7 @@
     
     /* 替换 WXWebComponent 的loadURL 方法*/
     Method originalMLoadUrl = class_getInstanceMethod([WXWebComponent class], @selector(loadURL:));
-    Method exchangeMLoadUrl = class_getInstanceMethod([WXWebComponent class], @selector(bm_lodaURL:));
+    Method exchangeMLoadUrl = class_getInstanceMethod([WXWebComponent class], @selector(bm_loadURL:));
     method_exchangeImplementations(originalMLoadUrl, exchangeMLoadUrl);
 }
 

--- a/BMWeexExtension/BMMethods.m
+++ b/BMWeexExtension/BMMethods.m
@@ -277,6 +277,10 @@
     Method exchangeMSetUrl = class_getInstanceMethod([WXWebComponent class], @selector(bm_setUrl:));
     method_exchangeImplementations(originalMSetUrl, exchangeMSetUrl);
     
+    /* 替换 WXWebComponent 的loadURL 方法*/
+    Method originalMLoadUrl = class_getInstanceMethod([WXWebComponent class], @selector(loadURL:));
+    Method exchangeMLoadUrl = class_getInstanceMethod([WXWebComponent class], @selector(bm_lodaURL:));
+    method_exchangeImplementations(originalMLoadUrl, exchangeMLoadUrl);
 }
 
 + (void)exchangeRecyclerComponent

--- a/BMWeexExtension/WXWebComponent+BMExtend.m
+++ b/BMWeexExtension/WXWebComponent+BMExtend.m
@@ -49,9 +49,9 @@
 /**
  这里主要判断是否是本地html，如果是本地html，则加载本地html
  */
--(void)bm_lodaURL:(NSString *)url
+-(void)bm_loadURL:(NSString *)url
 {
-    UIWebView *webview = (UIWebView *)[self valueForKey:@"webview"];
+    UIWebView * webview = (UIWebView *)self.view;
     
     if(webview){
         NSURL *urlPath = [NSURL URLWithString:url];

--- a/BMWeexExtension/WXWebComponent+BMExtend.m
+++ b/BMWeexExtension/WXWebComponent+BMExtend.m
@@ -46,5 +46,27 @@
     
     [self bm_setUrl:url];
 }
-
+/**
+ 这里主要判断是否是本地html，如果是本地html，则加载本地html
+ */
+-(void)bm_lodaURL:(NSString *)url
+{
+    UIWebView *webview = (UIWebView *)[self valueForKey:@"webview"];
+    
+    if(webview){
+        NSURL *urlPath = [NSURL URLWithString:url];
+        if([urlPath.scheme isEqualToString:BM_LOCAL]){
+            if (BM_InterceptorOn()) {
+                NSString *webPath = [NSString stringWithFormat:@"%@/%@%@",K_JS_PAGES_PATH,urlPath.host,urlPath.path];
+                NSURLRequest *request = [NSURLRequest requestWithURL:[[NSURL alloc]initFileURLWithPath:webPath]];
+                [webview loadRequest:request];
+            }else {
+                NSString *debugUrl = [NSString stringWithFormat:@"%@/dist/%@%@",TK_PlatformInfo().url.jsServer,urlPath.host,urlPath.path];
+                [self bm_lodaURL:debugUrl];
+            }
+        }else {
+            [self bm_lodaURL:url];
+        }
+    }
+}
 @end


### PR DESCRIPTION
## web标签读取src时，新增了可以使用bmlocal://打开放在assest目录内的html文件

demo:
```
   <web class="fixed-full-screen" src="bmlocal://assets/xxxxxx.html"></web>
```
