### PR TITLE
新增ectarts自定义样式

### DIFF
--- a/BMComponent/Chart/BMChartComponent.m
+++ b/BMComponent/Chart/BMChartComponent.m
@@ -18,6 +18,11 @@
 
 @property (nonatomic,strong) WKWebView *webview;    /**< webView */
 @property (nonatomic,copy) NSString *chartInfo;     /**< 图标数据 */
+@property (nonatomic,copy) NSString *useStyle; /**< 主题地址 >*/
+@property (nonatomic,copy) NSString *useStyleName; /**< 主题地址名字 >*/
+
+@property (nonatomic, strong) UIWebView *uiWebView;
+@property (nonatomic, strong) JSContext *context;
 
 /** event */
 @property (nonatomic,assign) BOOL finishEvent; /**< 图表加载完毕事件 */
@@ -36,6 +41,13 @@
             _chartInfo = [NSString stringWithFormat:@"%@",attributes[ChartInfo]];
         }
         
+        if(attributes[@"useStyle"]){
+            _useStyle = [NSString stringWithFormat:@"%@",attributes[@"useStyle"]];
+        }
+        if(attributes[@"useStyleName"]){
+            _useStyleName = [NSString stringWithFormat:@"%@",attributes[@"useStyleName"]];
+        }
+        
         [self createWebView];
         
     }
@@ -45,21 +57,41 @@
 - (void)createWebView
 {
     WXPerformBlockOnMainThread(^{
-        WKWebView *webview = [[WKWebView alloc] init];
+        //进行配置控制器
+        WKWebViewConfiguration *configuration = [[WKWebViewConfiguration alloc] init];
+        //实例化对象
+        configuration.userContentController = [WKUserContentController new];
+        [configuration.userContentController addScriptMessageHandler:self name:@"callMessage"];
+        WKPreferences *preferences = [WKPreferences new];
+        preferences.javaScriptCanOpenWindowsAutomatically = YES;
+//        preferences.minimumFontSize = 40.0;
+        configuration.preferences = preferences;
+        
+//        WKWebView *webview = [[WKWebView alloc] init];
+        WKWebView *webview = [[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 0, 0) configuration:configuration];
         webview.navigationDelegate = self;
         webview.scrollView.scrollEnabled = NO;
         webview.opaque = NO;
         
-        NSString *filePath = [[NSBundle mainBundle]pathForResource:@"bm-chart" ofType:@"html"];
+        NSString *filePath = [[NSBundle mainBundle] pathForResource:@"bm-chart" ofType:@"html"];
         NSString *htmlStr = [NSString stringWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:nil];
         [webview loadHTMLString:htmlStr baseURL:[NSURL URLWithString:htmlStr]];
         WXLogInfo(@"\n【webView】loadHTMLString");
 //        NSURL *url = [NSURL fileURLWithPath:filePath];
 //        [webview loadRequest:[NSURLRequest requestWithURL:url]];
         
+        
         self.webview = webview;
     });
 }
+
+#pragma mark - WKScriptMessageHandler
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message{
+    if([message.name isEqualToString:@"callMessage"]){
+        [self runChatInfo];
+    }
+}
+
 
 - (void)fillAttributes:(NSDictionary *)attributes
 {
@@ -114,9 +146,25 @@
     }];
 }
 
+- (void)runReadyChat{
+    if(self.useStyle){
+        NSString *script = [NSString stringWithFormat:@"setUrl('%@');",self.useStyle];
+        WXLogError(@"===>%@",script);
+        [self.webview evaluateJavaScript:script completionHandler:^(id _Nullable dict, NSError * _Nullable error) {
+            if (error) {
+                WXLogError(@"Run script:%@ Error:%@",script,error);
+            }
+        }];
+    }else{
+        [self runChatInfo];
+    }
+}
+
+
+
 - (void)runChatInfo
 {
-    NSString *script = [NSString stringWithFormat:@"setOption(%@)",self.chartInfo];
+    NSString *script = [NSString stringWithFormat:@"setOption(%@,\"%@\")",self.chartInfo,self.useStyleName];
     [self.webview evaluateJavaScript:script completionHandler:^(id _Nullable dict, NSError * _Nullable error) {
         if (error) {
             WXLogError(@"Run script:%@ Error:%@",script,error);
@@ -144,10 +192,10 @@
     NSString *echartJsPath = [[NSBundle mainBundle] pathForResource:@"echarts.min" ofType:@"js"];
     NSString *echartJsStr = [NSString stringWithContentsOfFile:echartJsPath encoding:NSUTF8StringEncoding error:nil];
     [self webViewRunScript:echartJsStr];
-
-    //    NSString *script = @"setOption({'tooltip':{'show':true},'legend':{'data':['数量（吨）']},'xAxis':[{'type':'category','data':['桔子','香蕉','苹果','西瓜']}],'yAxis':[{'type':'value'}],'series':[{'name':'数量（吨）','type':'bar','data':[100,200,300,400]}]})";
     
-    [self runChatInfo];
+    //    NSString *script = @"setOption({'tooltip':{'show':true},'legend':{'data':['数量（吨）']},'xAxis':[{'type':'category','data':['桔子','香蕉','苹果','西瓜']}],'yAxis':[{'type':'value'}],'series':[{'name':'数量（吨）','type':'bar','data':[100,200,300,400]}]})";
+//    [self runChatInfo];
+    [self runReadyChat];
 }
 
 - (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error

--- a/BMComponent/Chart/Resources/bm-chart.html
+++ b/BMComponent/Chart/Resources/bm-chart.html
@@ -8,11 +8,26 @@
             <meta name="apple-mobile-web-app-status-bar-style" content="black" />
             <meta name="format-detection" content="telephone=no,email=no" />
             <title>ECharts</title>
+            <script type="text/javascript">
+                /*
+                 *通过网络加载自定义样式，加载模板
+                 *<bmchart useStyle="https://www.sinomarinetech.com/utils/tjCurve.js" useStyleName="tjCurve" :options="$format(chertInfo)" @finish='finish'></bmchart>
+                 **/
+            function setUrl(url){
+                var script = document.createElement("script");
+                script.type = "text/javascript";
+                script.src = url;
+                script.onload = function(){
+                    window.webkit.messageHandlers.callMessage.postMessage('setTheme');
+                };
+                document.body.appendChild(script);
+            }
+            </script>
     </head>
     
-    <body style="margin:0; padding:0;">
+    <body style="margin:0; padding:0;background-color: transparent;">
         <!-- 为ECharts准备一个具备大小（宽高）的Dom -->
-        <div id="main" style="height:260px;width: 100%;"></div>
+        <div id="main" style="height:260px;width: 100%;background-color: transparent;"></div>
         <!-- ECharts单文件引入 -->
         <script type="text/javascript">
             
@@ -25,7 +40,7 @@
         /*
          
          */
-        function setOption(options) {
+        function setOption(options,name) {
             var formatOptions = JSON.parse(options,function(k,v){
                                            
                                            if(v.indexOf&&v.indexOf('function')>-1){
@@ -37,14 +52,13 @@
                                            return v;
                                            
                                            });
-                                           var myChart = echarts.init(mainDom);
+                                           var myChart = echarts.init(mainDom,name);
                                            // 使用刚指定的配置项和数据显示图表。
                                            myChart.setOption(formatOptions);
                                            
         }
-        </script>
-        <script type="text/javascript" src="echarts.min.js"></script>
         
+            </script>
+        <script type="text/javascript" src="echarts.min.js"></script>
     </body>
     
-</html>


### PR DESCRIPTION
`<bmchart useStyle="https://www.xxx.com/tjCurve.js" useStyleName="tjCurve" :options="$format(chertInfo)" @finish='finish'>`
针对echarts的主题构建工具http://echarts.baidu.com/theme-builder/。
下载自己的自定义样式js后，需放入自己服务器中或者oss。
新增两个属性，1、useStyle，放置在公网上加载自定义的主题样式js，2、useStyleName，代表该样式的名字。