### PR TITLE
【Fixed】增加新页面后通过热更新，新页面无法打开，提示‘页面路径不存在’的问题

### DIFF
--- a/BMManager/StartConfig/BMConfigManager.m
+++ b/BMManager/StartConfig/BMConfigManager.m
@@ -122,6 +122,7 @@
     [[YTKNetworkConfig sharedConfig] setCdnUrl:platformInfo.url.image];
     
     /** 应用最新js资源文件 */
+    [BMResourceManager sharedInstance].bmWidgetJs = nil;
     [[BMResourceManager sharedInstance] compareVersion];
     
     /** 初始化数据库 */


### PR DESCRIPTION
增加新页面后通过热更新，新页面无法打开，提示‘页面路径不存在’的问题